### PR TITLE
Land Development Engineering Site Reviews Query

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+
+.env
+.DS_Store
+env_file
+/.idea
+*.pyc
+/docs
+/.github

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .env
 .DS_Store
 env_file
+/.idea
+*.pyc

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ AMANDA is the backend system that underlies the [Austin Build + Connect](https:/
 
 `$ python amanda/amanda_to_s3.py --query applications_received`
 
+### Queries
+
+- `applications_received`: Gets the count of the number of right of way (ROW) permits received by day and folder type.
+- `active_permits`: Gets the current number of active ROW permits by type.
+- `issued_permits`: Gets the count of the number ROW permits issued by day and folder type.
+- `review_time`: Gets a list of dates of different processes of a RW permit's review timeline.
+- `ex_permits_issued`: Gets the list of EX permits and their indate and issuedate
+- `license_agreements_timeline`: Gets a list of license reviews and a series of dates of review completion dates. 
+- `lde_site_plan_revisions`: Gets a list of land development engineering reviews and key dates for reviews and their due dates.
+
 ## Smartsheet
 
 [Smartsheet](https://www.smartsheet.com/) is an additional tool the ROW team uses to manage some types of permits. `smartsheet_to_s3.py` downloads all of the data from the predefined list of sheets in `sheets.py` and stores the data as a .csv file in an AWS S3 bucket. There are no parameters for this script.

--- a/amanda/queries.py
+++ b/amanda/queries.py
@@ -155,39 +155,16 @@ QUERIES = {
         f.FOLDERTYPE in('LM') -- Land Management folder type only
         AND f.STATUSCODE NOT in(56050) -- Remove VOID status
     """,
-    "lde_site_plan_reviews":
-    """
-    SELECT
-        f.FOLDERRSN,
-        f.REFERENCEFILE,
-        f.FOLDERNAME,
-        f.SUBCODE,
-        sub.SUBDESC,
-        fp.PROCESSRSN,
-        f.FOLDERTYPE,
-        vs.STATUSDESC,
-        f.FOLDERCONDITION,
-        TO_CHAR(fp.STARTDATE, 'YYYY-MM-DD"T"HH24:MI:SS') as START_DATE,
-        TO_CHAR(fp.ENDDATE, 'YYYY-MM-DD"T"HH24:MI:SS') as END_DATE,
-        TO_CHAR(fp.SCHEDULEDATE, 'YYYY-MM-DD"T"HH24:MI:SS') as TO_START,
-        TO_CHAR(fp.SCHEDULEENDDATE, 'YYYY-MM-DD"T"HH24:MI:SS') as TO_END
-    FROM
-        FOLDER f
-        LEFT OUTER JOIN FOLDERPROCESS fp ON f.FOLDERRSN = fp.FOLDERRSN
-        left outer JOIN VALIDSUB sub on sub.SUBCODE = f.SUBCODE
-        left outer JOIN VALIDSTATUS vs on vs.STATUSCODE = f.statuscode
-    WHERE
-        fp.PROCESSCODE = 51212
-        and(f.FOLDERTYPE = 'SP'
-            OR f.FOLDERTYPE = 'SC'
-            or(f.FOLDERTYPE = 'DA'
-                AND f.SUBCODE = 51315))
-    """,
     "lde_site_plan_revisions":
     """
     SELECT
         f.FOLDERTYPE,
+        f.FOLDERREVISION,
         f.FOLDERRSN,
+        f.SUBCODE,
+        sub.SUBDESC,
+        vs.STATUSDESC,
+        f.FOLDERCONDITION,
         f.REFERENCEFILE,
         f.FOLDERNAME,
         vu.USERNAME AS REVIEWER,
@@ -211,8 +188,11 @@ QUERIES = {
         JOIN validprocessstatus vps ON vps.STATUSCODE = fp.STATUSCODE
         JOIN propertyinfo pi ON pi.PROPERTYRSN = f.PROPERTYRSN
             AND pi.PROPERTYINFOCODE = 52026 --Propertyinfo-Council District
+        left outer JOIN VALIDSUB sub on sub.SUBCODE = f.SUBCODE
+        left outer JOIN VALIDSTATUS vs on vs.STATUSCODE = f.statuscode
     GROUP BY
         f.FOLDERTYPE,
+        f.FOLDERREVISION,
         vp.PROCESSDESC,
         f.FOLDERRSN,
         f.REFERENCEFILE,
@@ -225,7 +205,11 @@ QUERIES = {
         fp.STARTDATE,
         fp.ENDDATE,
         vps.STATUSDESC,
-        pi.PROPINFOVALUE
+        pi.PROPINFOVALUE,
+        f.SUBCODE,
+        sub.SUBDESC,
+        vs.STATUSDESC,
+        f.FOLDERCONDITION
     ORDER BY
         vu.USERNAME,
         f.FOLDERTYPE,

--- a/metrics/socrata_config.py
+++ b/metrics/socrata_config.py
@@ -4,11 +4,6 @@ DATASETS = {
         "resource_id": "arae-ym9d",
         "sodapy_method": "replace",
     },
-    "lde_site_plan_reviews": {
-        "file_name": "lde_site_plan_reviews.csv",
-        "resource_id": "tnkv-vsec",
-        "sodapy_method": "upsert",
-    },
     "lde_site_plan_revisions": {
         "file_name": "lde_site_plan_revisions.csv",
         "resource_id": "bek3-sdgd",

--- a/metrics/socrata_config.py
+++ b/metrics/socrata_config.py
@@ -3,5 +3,15 @@ DATASETS = {
         "file_name": "license_agreements_timeline.csv",
         "resource_id": "arae-ym9d",
         "sodapy_method": "replace",
-    }
+    },
+    "lde_site_plan_reviews": {
+        "file_name": "lde_site_plan_reviews.csv",
+        "resource_id": "tnkv-vsec",
+        "sodapy_method": "upsert",
+    },
+    "lde_site_plan_revisions": {
+        "file_name": "lde_site_plan_revisions.csv",
+        "resource_id": "bek3-sdgd",
+        "sodapy_method": "upsert",
+    },
 }


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/17718

New AMANDA query and [dataset](https://datahub.austintexas.gov/dataset/Land-Development-Engineering-Revisions/bek3-sdgd/about_data) I've created about LDE site plan reviews/revisions. 

This feeds a new tab in the license agreements Power BI report (testing workspace):
https://app.powerbigov.us/links/pjlZY4Rb1r?ctid=5c5e19f6-a6ab-4b45-b1d0-be4608a9a67f&pbi_source=linkShare

### Testing
#### Code
If you want to test the code, I have supplied a env_template, the [airflow DAG](https://github.com/cityofaustin/atd-airflow/blob/production/dags/dts_row_reporting.py) shows where each item exists in 1password.

Step 1. upload query as csv into S3
```
python amanda/amanda_to_s3.py --query lde_site_plan_revisions
```

Step 2. load data into socrata dataset
```
python metrics/s3_to_socrata.py --dataset lde_site_plan_revisions
```

#### Query
If you want to test the query by itself, you can copy `lde_site_plan_revisions` from queries.py into a DB viewer that supports Oracle. You can get the AMANDA read replica credentials in 1password as well.

#### Power BI
I've posted the link to the Power BI report above, feel free to poke around and see if things are making sense. Tracy also has requirements in attached issue.

#### Airflow
I'll make a companion PR for airflow after this is merged ✅ 