### PR TITLE
New SIF amanda query/dataset

### DIFF
--- a/amanda/queries.py
+++ b/amanda/queries.py
@@ -440,5 +440,58 @@ QUERIES = {
         AND f.statuscode != 70045
     ORDER BY
         f.folderrsn
+    """,
+    "sif_payment_details":
+    """
+    SELECT DISTINCT
+        f.folderrsn,
+        f.parentrsn,
+        p.PropHouse || ' ' || p.PropStreet || ' ' || p.PropStreetType || ' ' || p.PropStreetDirection || ' ' || p.PropUnitType || ' ' || p.PropUnit || ' ' || p.propprovince || ' ' || p.proppostal AS primary_folder_property,
+        fp.propertyrsn AS primary_folder_property_propid,
+        p.propertyroll AS primary_folder_property_roll,
+        pi.propinfovalue AS primary_folder_property_segm,
+        FI1.infovalue AS council_district,
+        FI2.infovalue AS sif_district_area,
+        apd.paymentnumber AS paymentnumber,
+        apd.paymentamount AS paymentamount,
+        ab.billnumber AS billnumber,
+        TO_CHAR(apd.dategenerated , 'YYYY-MM-DD"T"HH24:MI:SS') paymentdate,
+        TO_CHAR(apd.dategenerated, 'Month') AS payment_month,
+        CASE 
+            WHEN EXTRACT(MONTH FROM apd.dategenerated) IN (10, 11, 12) THEN 'Q1'
+            WHEN EXTRACT(MONTH FROM apd.dategenerated) IN (1, 2, 3) THEN 'Q2'
+            WHEN EXTRACT(MONTH FROM apd.dategenerated) IN (4, 5, 6) THEN 'Q3'
+            WHEN EXTRACT(MONTH FROM apd.dategenerated) IN (7, 8, 9) THEN 'Q4'
+        END AS payment_quarter,
+        CASE 
+            WHEN EXTRACT(MONTH FROM apd.dategenerated) >= 10 
+                THEN EXTRACT(YEAR FROM apd.dategenerated) + 1
+            ELSE EXTRACT(YEAR FROM apd.dategenerated)
+        END AS payment_fy
+    FROM
+        folder f
+        JOIN folderfreeform ff ON f.folderrsn = ff.folderrsn
+        JOIN accountbill ab ON f.folderrsn = ab.folderrsn
+        JOIN Accountbillfee abf ON abf.folderrsn = ab.folderrsn
+        AND abf.billnumber = ab.billnumber
+        JOIN accountpaymentdetail apd ON apd.folderrsn = ab.folderrsn
+        AND apd.billnumber = ab.Billnumber
+        JOIN accountpayment ap ON apd.folderrsn = ap.folderrsn
+        AND ap.paymentnumber = apd.paymentnumber
+        AND ap.voidflag <> 'Y'
+        JOIN validstatus vs ON f.statuscode = vs.statuscode
+        JOIN folderproperty fp ON f.folderrsn = fp.folderrsn
+        AND f.propertyrsn = fp.propertyrsn
+        JOIN property p ON p.propertyrsn = fp.propertyrsn
+        JOIN propertyinfo pi ON p.propertyrsn = pi.propertyrsn
+        AND pi.propertyinfocode = 55005
+        JOIN FOLDERINFO FI1 ON F.FOLDERRSN = FI1.FOLDERRSN
+        AND FI1.INFOCODE = 84011
+        JOIN FOLDERINFO FI2 ON F.FOLDERRSN = FI2.FOLDERRSN
+        AND FI2.INFOCODE = 84012
+    WHERE
+        f.foldertype = 'SIF'
+    ORDER BY
+        f.folderrsn
     """
 }

--- a/amanda/queries.py
+++ b/amanda/queries.py
@@ -379,8 +379,7 @@ QUERIES = {
                 fp.processrsn
         )
     """,
-    "tds_asmd_map":
-    """
+    "tds_asmd_map": """
     SELECT
         f.folderrsn,
         f.parentrsn,
@@ -441,8 +440,7 @@ QUERIES = {
     ORDER BY
         f.folderrsn
     """,
-    "sif_payment_details":
-    """
+    "sif_payment_details": """
     SELECT DISTINCT
         f.folderrsn,
         f.parentrsn,
@@ -493,5 +491,5 @@ QUERIES = {
         f.foldertype = 'SIF'
     ORDER BY
         f.folderrsn
-    """
+    """,
 }

--- a/metrics/socrata_config.py
+++ b/metrics/socrata_config.py
@@ -18,5 +18,10 @@ DATASETS = {
         "file_name": "tds_asmd_map.csv",
         "resource_id": "2jm8-nsf3",
         "sodapy_method": "replace",
+    },
+    "sif_payment_details": {
+        "file_name": "sif_payment_details.csv",
+        "resource_id": "kaw2-pkp2",
+        "sodapy_method": "replace",
     }
 }

--- a/metrics/socrata_config.py
+++ b/metrics/socrata_config.py
@@ -23,5 +23,5 @@ DATASETS = {
         "file_name": "sif_payment_details.csv",
         "resource_id": "kaw2-pkp2",
         "sodapy_method": "replace",
-    }
+    },
 }


### PR DESCRIPTION
part of [25091](https://github.com/cityofaustin/atd-data-tech/issues/25091)

[Dataset here](https://datahub.austintexas.gov/dataset/Street-Impact-Fee-Payment-Details/kaw2-pkp2/about_data)

New SIF payments dataset.

***

### Testing

You must be on city VPN in order to connect to the AMANDA read replica DB

#### Code
If you want to test the code, I have supplied a env_template, the [airflow DAG](https://github.com/cityofaustin/atd-airflow/blob/production/dags/dts_row_reporting.py) shows where each item exists in 1password.

I built my environment with conda and `pip install -r requirements.txt` but you can also use the dockerfile.

Step 1. upload query as csv into S3
```
python amanda/amanda_to_s3.py --query sif_payment_details
```

Step 2. load data into socrata dataset
```
python metrics/s3_to_socrata.py --dataset sif_payment_details
```

#### Query
If you want to test the query by itself, you can copy `sif_payment_details` from queries.py into a DB viewer that supports Oracle. You can get the AMANDA read replica credentials in 1password as well.

#### Airflow
I'll make a companion PR for airflow after this is merged ✅ 