### PR TITLE
add new process codes to LDE Revisions 

### DIFF
--- a/amanda/queries.py
+++ b/amanda/queries.py
@@ -201,7 +201,7 @@ QUERIES = {
     FROM
         folder f
         JOIN folderprocess fp ON fp.FOLDERRSN = f.FOLDERRSN
-            AND fp.PROCESSCODE IN(51212)
+            AND fp.PROCESSCODE IN(51212, 51258, 51259)
         JOIN validprocess vp ON vp.PROCESSCODE = fp.PROCESSCODE
         LEFT JOIN validuser vu ON vu.USERID = fp.ASSIGNEDUSER
         JOIN validprocessstatus vps ON vps.STATUSCODE = fp.STATUSCODE


### PR DESCRIPTION
Issue: https://github.com/cityofaustin/atd-data-tech/issues/26847

From the issue:

> We are adding 2 AMANDA process codes to the [Land Development Engineering Revisions](https://datahub.austintexas.gov/dataset/Land-Development-Engineering-Revisions/bek3-sdgd/about_data) data set.
> 
> ATPW-LDE Row Compliance Review (51258)
> ATPW-LDE Driveway/Sidewalk Review (51259)
> Rename tab from 'Site Plan' to 'Plan Review'

## Testing

Verify I added the above process codes to the `lde_site_plan_revisions` query.

# **Only if you really want to test the code:**

#### Code

You must be on city VPN in order to connect to the AMANDA read replica DB

If you want to test the code, I have supplied a env_template, the [airflow DAG](https://github.com/cityofaustin/atd-airflow/blob/production/dags/dts_row_reporting.py) shows where each item exists in 1password.

I built my environment with conda and `pip install -r requirements.txt` but you can also use the dockerfile.

Step 1. upload query as csv into S3
```
python amanda/amanda_to_s3.py --query lde_site_plan_revisions
```

Step 2. load data into socrata dataset
```
python metrics/s3_to_socrata.py --dataset lde_site_plan_revisions
```

Check the [dataset](https://datahub.austintexas.gov/dataset/Land-Development-Engineering-Revisions/bek3-sdgd/about_data) that it has a few records "ATPW-LDE Driveway/Sidewalk Review" and "ATPW-LDE Row Compliance Review" under `process_name`



