### PR TITLE
add DA + SC foldertypes to cases query

### DIFF
--- a/amanda/queries.py
+++ b/amanda/queries.py
@@ -376,7 +376,7 @@ QUERIES = {
                 JOIN propertyinfo pi ON pi.propertyrsn = f.propertyrsn
                 AND pi.propertyinfocode = 52026 --Propertyinfo-Council District
             WHERE
-                f.foldertype IN ('C8', 'SP', 'ZC', 'PR', 'CC')
+                f.foldertype IN ('C8', 'SP', 'ZC', 'PR', 'CC', 'DA', 'SC')
             GROUP BY
                 f.foldertype,
                 vp.PROCESSDESC,


### PR DESCRIPTION
[#27562](https://github.com/cityofaustin/atd-data-tech/issues/27562) - Update/Create EDP for TDS AMANDA Review Data

Adds DA and SC foldertypes to the TDS cases query

*** 

If you want to test this fully let me know, I don't know that it is super necessary. I did test this query with the script and received about 706 DA+SC cases. They might still be in the [dataset](https://datahub.austintexas.gov/dataset/Transportation-Development-Services-Cases/uzv7-zdtt/about_data) if you are looking before it is overwritten by the prod code deployed in airflow.