### PR TITLE
add work type to LDE query

### DIFF
--- a/amanda/queries.py
+++ b/amanda/queries.py
@@ -128,6 +128,7 @@ QUERIES = {
         sub.SUBDESC,
         vs.STATUSDESC,
         f.FOLDERCONDITION,
+        vw.WORKDESC,
         TO_CHAR(f.INDATE, 'YYYY-MM-DD"T"HH24:MI:SS') AS INDATE,
         TO_CHAR(web_acceptance.ATTDATE, 'YYYY-MM-DD"T"HH24:MI:SS') AS WEB_APP_ACCEPT_DATE,
         TO_CHAR(payment.ATTDATE, 'YYYY-MM-DD"T"HH24:MI:SS') AS PAYMENT_COMPLETED_DATE,
@@ -150,7 +151,7 @@ QUERIES = {
         LEFT OUTER JOIN (
         SELECT
             fp.FOLDERRSN,
-            min(fpa.ATTEMPTDATE) AS ATTDATE -- Getting latest completed distribution 
+            min(fpa.ATTEMPTDATE) AS ATTDATE -- Getting latest completed distribution
         FROM
             FOLDERPROCESS fp
             LEFT OUTER JOIN FOLDERPROCESSATTEMPT fpa ON fpa.PROCESSRSN = fp.PROCESSRSN
@@ -171,6 +172,7 @@ QUERIES = {
             FOLDERRSN) reviews ON f.FOLDERRSN = reviews.FOLDERRSN
         left outer JOIN VALIDSUB sub on sub.SUBCODE = f.SUBCODE
         left outer JOIN VALIDSTATUS vs on vs.STATUSCODE = f.statuscode
+        left outer JOIN VALIDWORK vw on vw.WORKCODE = f.workcode
     WHERE
         f.FOLDERTYPE in('LM') -- Land Management folder type only
         AND f.STATUSCODE NOT in(56050) -- Remove VOID status


### PR DESCRIPTION
[#28045](https://github.com/cityofaustin/atd-data-tech/issues/28045) - Update License Agreement Page of LDE's PBI Dashboard

***

Adding new work type column to this [dataset](https://datahub.austintexas.gov/dataset/License-Agreement-Permit-Review-Timelines/arae-ym9d/about_data).

***

If you feel like testing this see below. If you are checking it today the WORKDESC column in the dataset should still be populated to see if that is working 👍 

### Testing

You must be on city VPN in order to connect to the AMANDA read replica DB

#### Code
If you want to test the code, I have supplied a env_template, the [airflow DAG](https://github.com/cityofaustin/atd-airflow/blob/production/dags/dts_row_reporting.py) shows where each item exists in 1password.

I built my environment with conda and `pip install -r requirements.txt` but you can also use the dockerfile.

Step 1. upload query as csv into S3
```
python amanda/amanda_to_s3.py --query license_agreements_timeline
```

Step 2. load data into socrata dataset
```
python metrics/s3_to_socrata.py --dataset license_agreements_timeline
```


